### PR TITLE
Added resourcedetection and resorce processors

### DIFF
--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -407,6 +407,30 @@ spec:
 
     processors:
       cumulativetodelta:
+      resourcedetection:
+        detectors: [env, azure]
+        azure:
+          resource_attributes:
+            cloud.provider:
+              enabled: true
+            cloud.platform:
+              enabled: false
+            cloud.region:
+              enabled: true
+            cloud.account.id:
+              enabled: false
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            azure.vm.name:
+              enabled: false
+            azure.vm.size:
+              enabled: true
+            azure.vm.scaleset.name:
+              enabled: false
+            azure.resourcegroup.name:
+              enabled: false
       k8sattributes:
         extract:
           metadata:
@@ -428,6 +452,13 @@ spec:
           - key: k8s.cluster.name
             value: {{ .Values.clusterName }}
             action: upsert
+      resource:
+        attributes:
+          - key: vm.type
+            action: upsert
+            from_attribute: azure.vm.size
+          - key: azure.vm.size
+            action: delete
       attributes/self:
         actions:
           - key: otelcollector.type
@@ -552,8 +583,10 @@ spec:
             - prometheus/self
           processors:
             - cumulativetodelta
+            - resourcedetection
             - k8sattributes
             - attributes
+            - resource
             - attributes/self
             - memory_limiter
             - batch
@@ -568,8 +601,10 @@ spec:
             - prometheus
           processors:
             - cumulativetodelta
+            - resourcedetection
             - k8sattributes
             - attributes
+            - resource
             - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
@@ -588,8 +623,10 @@ spec:
             - prometheus
           processors:
             - cumulativetodelta
+            - resourcedetection
             - k8sattributes
             - attributes
+            - resource
             - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}


### PR DESCRIPTION
# Changes

- `resourcedetectionprocessor` is added to collect the `cloud.provider`, `cloud.region` and `azure.vm.size` attributes.
  - Currently, it only fetches Azure.
- `resourceprocessor` is added to convert the `azure.vm.size` attribute into `vm.type` in order to unify AKS, EKS & GKE VM types.