### PR TITLE
Upgraded collectors and operator

### DIFF
--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -107,7 +107,7 @@ deployment:
     # Image pull policy
     pullPolicy: IfNotPresent
     # Image tag
-    tag: "0.84.0"
+    tag: "0.86.0"
 
   # Service account
   serviceAccount:
@@ -229,7 +229,7 @@ daemonset:
     # Image pull policy
     pullPolicy: IfNotPresent
     # Image tag
-    tag: "0.84.0"
+    tag: "0.86.0"
 
   # Service account
   serviceAccount:
@@ -352,7 +352,7 @@ statefulset:
     # Image pull policy
     pullPolicy: IfNotPresent
     # Image tag
-    tag: "0.84.0"
+    tag: "0.86.0"
 
   # Amount of replicas
   replicas: 2

--- a/helm/scripts/00_deploy_operator.sh
+++ b/helm/scripts/00_deploy_operator.sh
@@ -26,7 +26,7 @@ helm upgrade ${certmanager[name]} \
   --debug \
   --create-namespace \
   --namespace ${certmanager[namespace]} \
-  --version v1.11.0 \
+  --version v1.13.1 \
   --set installCRDs=true \
   "jetstack/cert-manager"
 
@@ -37,4 +37,5 @@ helm upgrade ${oteloperator[name]} \
   --debug \
   --create-namespace \
   --namespace ${oteloperator[namespace]} \
+  --version "0.40.0" \
   "open-telemetry/opentelemetry-operator"


### PR DESCRIPTION
# Changes

- Collectors are upgraded to `0.86.0`.
- Operator is upgraded to `0.86.0` -> compatible Helm version is `0.40.0`.
- Cert manager is upgraded to `1.13.1`.
