### PR TITLE
Exposed replicas as variable

### DIFF
--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -9,6 +9,9 @@ spec:
   # Mode
   mode: "deployment"
 
+  # Replicas
+  replicas: {{ .Values.deployment.replicas.receiver }}
+
   # Service Account
   serviceAccount: {{ include "nrotel.deploymentName" . }}
 

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -9,6 +9,9 @@ spec:
   # Mode
   mode: "deployment"
 
+  # Replicas
+  replicas: {{ .Values.deployment.replicas.sampler }}
+
   # Service Account
   serviceAccount: {{ include "nrotel.deploymentName" . }}
 

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -9,8 +9,8 @@ spec:
   # Mode
   mode: "statefulset"
 
-  # Number of replicas
-  replicas: 2
+  # Replicas
+  replicas: {{ .Values.statefulset.replicas }}
 
   # Service Account
   serviceAccount: {{ include "nrotel.statefulsetName" . }}

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -112,6 +112,13 @@ deployment:
     # Image tag
     tag: "0.86.0"
 
+  # Number of replicas
+  replicas:
+    # Receiver collectors
+    receiver: 1
+    # Sampler collectors
+    sampler: 1
+
   # Service account
   serviceAccount:
     # Annotations to add to the service account
@@ -363,7 +370,7 @@ statefulset:
     # Image tag
     tag: "0.86.0"
 
-  # Amount of replicas
+  # Number of replicas
   replicas: 2
 
   # Service account


### PR DESCRIPTION
# Changes

- Number of replicas are exposed as Helm variables so that they can be set externally by the user.