### PR TITLE
Fixed cluster role missing access to namespaces

### DIFF
--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -138,6 +138,7 @@ deployment:
           - ""
         resources:
           - pods
+          - namespaces
         verbs:
           - get
           - watch


### PR DESCRIPTION
# Changes

- `namespaces` as resources are added to the clusterrole for deployments