### PR TITLE
Implemented Prometheus pod scraping

### DIFF
--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -17,6 +17,13 @@ spec:
   securityContext: {{ toYaml . | nindent 4 }}
   {{- end }}
 
+  # Annotations for the pods
+  podAnnotations:
+    prometheus.io/scrape: "false" # This should be false by default. Otherwise 'otelcollector' self scraper job AND 'kubernetes-pods' scrape job will both scrape
+  {{- range $key, $val := .Values.daemonset.annotations }}
+    {{ $key }}: {{ $val }}
+  {{- end }}
+
   # Ports to expose per service
   ports:
     - name: prometheus

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -20,6 +20,13 @@ spec:
   securityContext: {{ toYaml . | nindent 4 }}
   {{- end }}
 
+  # Annotations for the pods
+  podAnnotations:
+    prometheus.io/scrape: "false" # This should be false by default. Otherwise 'otelcollector' self scraper job AND 'kubernetes-pods' scrape job will both scrape
+  {{- range $key, $val := .Values.deployment.annotations }}
+    {{ $key }}: {{ $val }}
+  {{- end }}
+
   # Ports to expose per service
   ports:
     - name: prometheus

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -20,6 +20,13 @@ spec:
   securityContext: {{ toYaml . | nindent 4 }}
   {{- end }}
 
+  # Annotations for the pods
+  podAnnotations:
+    prometheus.io/scrape: "false" # This should be false by default. Otherwise 'otelcollector' self scraper job AND 'kubernetes-pods' scrape job will both scrape
+  {{- range $key, $val := .Values.deployment.annotations }}
+    {{ $key }}: {{ $val }}
+  {{- end }}
+
   # Ports to expose per service
   ports:
     - name: prometheus

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -20,6 +20,13 @@ spec:
   securityContext: {{ toYaml . | nindent 4 }}
   {{- end }}
 
+  # Annotations for the pods
+  podAnnotations:
+    prometheus.io/scrape: "false" # This should be false by default. Otherwise 'otelcollector' self scraper job AND 'kubernetes-pods' scrape job will both scrape
+  {{- range $key, $val := .Values.deployment.annotations }}
+    {{ $key }}: {{ $val }}
+  {{- end }}
+
   # Ports to expose per service
   ports:
     - name: prometheus

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -15,6 +15,13 @@ spec:
   # Service Account
   serviceAccount: {{ include "nrotel.statefulsetName" . }}
 
+  # Annotations for the pods
+  podAnnotations:
+    prometheus.io/scrape: "false" # This should be false by default. Otherwise 'otelcollector' self scraper job AND 'kubernetes-pods' scrape job will both scrape
+  {{- range $key, $val := .Values.statefulset.annotations }}
+    {{ $key }}: {{ $val }}
+  {{- end }}
+
   # Target allocator
   targetAllocator:
     enabled: true
@@ -406,6 +413,47 @@ spec:
                 - source_labels: [__meta_kubernetes_service_name]
                   action: replace
                   target_label: service
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  action: replace
+                  target_label: node
+
+            - job_name: 'kubernetes-pods'
+            {{- if .Values.statefulset.prometheus.lowDataMode }}
+              scrape_interval: 60s
+            {{- else }}
+              scrape_interval: 30s
+            {{- end }}
+              honor_labels: true
+
+              kubernetes_sd_configs:
+                - role: pod
+
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape_slow]
+                  action: drop
+                  regex: true
+                - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+                  action: replace
+                  target_label: __scheme__
+                  regex: (https?)
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  target_label: __address__
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $$1:$$2
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  action: replace
+                  target_label: pod
                 - source_labels: [__meta_kubernetes_pod_node_name]
                   action: replace
                   target_label: node

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -127,6 +127,9 @@ deployment:
   # Security context for container priviliges
   securityContext: {}
 
+  # Annotations for collector pods
+  annotations: {}
+
   clusterRole:
     # Annotations to add to the clusterRole
     # Can be used in combination with presets that create a cluster role.
@@ -252,6 +255,9 @@ daemonset:
 
   # Security context for container priviliges
   securityContext: {}
+
+  # Annotations for collector pods
+  annotations: {}
 
   clusterRole:
     # Annotations to add to the clusterRole
@@ -381,6 +387,9 @@ statefulset:
 
   # Security context for container priviliges
   securityContext: {}
+
+  # Annotations for collector pods
+  annotations: {}
 
   clusterRole:
     # Annotations to add to the clusterRole
@@ -583,6 +592,9 @@ singleton:
 
   # Security context for container priviliges
   securityContext: {}
+
+  # Annotations for collector pods
+  annotations: {}
 
   clusterRole:
     # Annotations to add to the clusterRole


### PR DESCRIPTION
# Changes

- New scrape job of `kubernetes-pods` is added.
- External assignment of annotations on collector pods is configured.
- Default annotation of `prometheus.io/scrape: "false"` is given to collector pods in order to avoid duplicate scraping per:
  - self scrape job (`otelcollector`) of each collector
  - new pod scrape job (`kubernetes-pods`) of `statefulset` collector