### PR TITLE
Upgraded Terraform provider to 3.27.3

### DIFF
--- a/monitoring/terraform/00_main.tf
+++ b/monitoring/terraform/00_main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = ">=3.20.2"
+      version = ">=3.27.3"
     }
   }
 }


### PR DESCRIPTION
# Changes

- Terraform provider is upgraded to `3.27.3`.