### PR TITLE
Added necessary kube-events & logs to cluster overview dashboard

### DIFF
--- a/monitoring/terraform/04_dashboard_cluster_overview.tf
+++ b/monitoring/terraform/04_dashboard_cluster_overview.tf
@@ -531,7 +531,7 @@ resource "newrelic_one_dashboard" "cluster_overview" {
             (
               FROM Metric SELECT uniques(replicaset)
                 WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
-                  AND metricName LIKE 'kube_replicaset_status_replicas' AND namespace IN ({{namespaces}})
+                  AND replicaset IS NOT NULL AND metricName = 'kube_replicaset_status_replicas' AND namespace IN ({{namespaces}})
                 LIMIT MAX
             )
         EOF
@@ -555,7 +555,7 @@ resource "newrelic_one_dashboard" "cluster_overview" {
             (
               FROM Metric SELECT uniques(daemonset)
                 WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
-                  AND metricName LIKE 'kube_daemonset_status_number_available' AND namespace IN ({{namespaces}})
+                  AND daemonset IS NOT NULL AND metricName = 'kube_daemonset_status_number_available' AND namespace IN ({{namespaces}})
                 LIMIT MAX
             )
         EOF
@@ -579,7 +579,7 @@ resource "newrelic_one_dashboard" "cluster_overview" {
             (
               FROM Metric SELECT uniques(statefulset)
                 WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
-                  AND metricName LIKE 'kube_statefulset_status_replicas' AND namespace IN ({{namespaces}})
+                  AND statefulset IS NOT NULL AND metricName = 'kube_statefulset_status_replicas' AND namespace IN ({{namespaces}})
                 LIMIT MAX
             )
         EOF

--- a/monitoring/terraform/04_dashboard_cluster_overview.tf
+++ b/monitoring/terraform/04_dashboard_cluster_overview.tf
@@ -870,7 +870,8 @@ resource "newrelic_one_dashboard" "cluster_overview" {
             (
               FROM Metric SELECT uniques(pod)
                 WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
-                  AND pod IS NOT NULL AND metricName = 'kube_pod_info' AND k8s.node.name IN ({{nodes}}) AND namespace IN ({{namespaces}}) LIMIT MAX
+                  AND pod IS NOT NULL AND metricName = 'kube_pod_info' AND node IN ({{nodes}}) AND namespace IN ({{namespaces}})
+                LIMIT MAX
             )
         EOF
       }

--- a/monitoring/terraform/04_dashboard_cluster_overview.tf
+++ b/monitoring/terraform/04_dashboard_cluster_overview.tf
@@ -218,9 +218,9 @@ resource "newrelic_one_dashboard" "cluster_overview" {
       }
     }
 
-    # Collector events
+    # Node events
     widget_log_table {
-      title  = "Collector events"
+      title  = "Node events"
       row    = 15
       column = 1
       height = 5

--- a/monitoring/terraform/04_dashboard_cluster_overview.tf
+++ b/monitoring/terraform/04_dashboard_cluster_overview.tf
@@ -852,6 +852,29 @@ resource "newrelic_one_dashboard" "cluster_overview" {
         EOF
       }
     }
+
+    # Pod events
+    widget_log_table {
+      title  = "Pod events"
+      row    = 17
+      column = 1
+      height = 5
+      width  = 12
+
+      nrql_query {
+        account_id = var.NEW_RELIC_ACCOUNT_ID
+        query      = <<EOF
+        FROM Log SELECT *
+          WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}'
+            AND k8s.object.kind = 'Pod' AND k8s.object.name IN
+            (
+              FROM Metric SELECT uniques(pod)
+                WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
+                  AND pod IS NOT NULL AND metricName = 'kube_pod_info' AND k8s.node.name IN ({{nodes}}) AND namespace IN ({{namespaces}}) LIMIT MAX
+            )
+        EOF
+      }
+    }
   }
 
   # Nodes

--- a/monitoring/terraform/04_dashboard_cluster_overview.tf
+++ b/monitoring/terraform/04_dashboard_cluster_overview.tf
@@ -217,6 +217,24 @@ resource "newrelic_one_dashboard" "cluster_overview" {
         EOF
       }
     }
+
+    # Collector events
+    widget_log_table {
+      title  = "Collector events"
+      row    = 15
+      column = 1
+      height = 5
+      width  = 12
+
+      nrql_query {
+        account_id = var.NEW_RELIC_ACCOUNT_ID
+        query      = <<EOF
+        FROM Log SELECT *
+          WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}'
+            AND k8s.object.kind = 'Node' AND k8s.object.name IN ({{nodes}})
+        EOF
+      }
+    }
   }
 
   ##########################

--- a/monitoring/terraform/04_dashboard_cluster_overview.tf
+++ b/monitoring/terraform/04_dashboard_cluster_overview.tf
@@ -513,6 +513,78 @@ resource "newrelic_one_dashboard" "cluster_overview" {
         EOF
       }
     }
+
+    # Replicaset events
+    widget_log_table {
+      title  = "Replicaset events"
+      row    = 11
+      column = 1
+      height = 4
+      width  = 12
+
+      nrql_query {
+        account_id = var.NEW_RELIC_ACCOUNT_ID
+        query      = <<EOF
+        FROM Log SELECT *
+          WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}'
+            AND k8s.object.kind = 'ReplicaSet' AND k8s.object.name IN
+            (
+              FROM Metric SELECT uniques(replicaset)
+                WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
+                  AND metricName LIKE 'kube_replicaset_status_replicas' AND namespace IN ({{namespaces}})
+                LIMIT MAX
+            )
+        EOF
+      }
+    }
+
+    # Daemonset events
+    widget_log_table {
+      title  = "Daemonset events"
+      row    = 15
+      column = 1
+      height = 4
+      width  = 12
+
+      nrql_query {
+        account_id = var.NEW_RELIC_ACCOUNT_ID
+        query      = <<EOF
+        FROM Log SELECT *
+          WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}'
+            AND k8s.object.kind = 'DaemonSet' AND k8s.object.name IN
+            (
+              FROM Metric SELECT uniques(daemonset)
+                WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
+                  AND metricName LIKE 'kube_daemonset_status_number_available' AND namespace IN ({{namespaces}})
+                LIMIT MAX
+            )
+        EOF
+      }
+    }
+
+    # Statefulset events
+    widget_log_table {
+      title  = "Statefulset events"
+      row    = 19
+      column = 1
+      height = 4
+      width  = 12
+
+      nrql_query {
+        account_id = var.NEW_RELIC_ACCOUNT_ID
+        query      = <<EOF
+        FROM Log SELECT *
+          WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}'
+            AND k8s.object.kind = 'StatefulSet' AND k8s.object.name IN
+            (
+              FROM Metric SELECT uniques(statefulset)
+                WHERE instrumentation.provider = 'opentelemetry' AND k8s.cluster.name = '${var.cluster_name}' AND service.name = 'kubernetes-kube-state-metrics'
+                  AND metricName LIKE 'kube_statefulset_status_replicas' AND namespace IN ({{namespaces}})
+                LIMIT MAX
+            )
+        EOF
+      }
+    }
   }
 
   ####################


### PR DESCRIPTION
# Changes

- Node events are added to node overview.
- ReplicaSet, DaemonSet and StatefulSet events are added to namespace overview.
- Pod events and logs are added to pod overview.