### PR TITLE
Added new important metrics

### DIFF
--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -153,7 +153,7 @@ spec:
                 - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
                   action: keep
                   regex: default;kubernetes;https
-              
+
               {{- if .Values.statefulset.prometheus.importantMetricsOnly }}
               metric_relabel_configs:
                 - source_labels: [__name__]
@@ -363,7 +363,7 @@ spec:
               {{- if .Values.statefulset.prometheus.importantMetricsOnly }}
               metric_relabel_configs:
                 - source_labels: [__name__]
-                  regex: kube_pod_status_phase|kube_pod_container_status_waiting|kube_pod_status_scheduled_time|kube_daemonset_created|kube_deployment_status_replicas_unavailable|kube_deployment_status_condition|kube_replicaset_status_ready_replicas|kube_statefulset_replicas|kube_pod_start_time|kube_pod_status_reason|kube_pod_container_resource_limits|kube_pod_status_scheduled|kube_pod_container_resource_requests|kube_pod_status_container_ready_time|kube_pod_container_status_terminated|kube_pod_container_status_ready|kube_statefulset_status_replicas_updated|kube_statefulset_status_replicas_ready|kube_daemonset_status_desired_number_scheduled|kube_deployment_status_replicas_ready|kube_pod_container_state_started|kube_statefulset_created|kube_daemonset_status_updated_number_scheduled|kube_statefulset_status_replicas_current|kube_daemonset_status_number_ready|kube_pod_container_status_running|kube_pod_created|kube_pod_container_status_restarts_total|kube_daemonset_status_number_unavailable
+                  regex: kube_pod_info|kube_pod_status_phase|kube_pod_container_status_waiting|kube_pod_status_scheduled_time|kube_daemonset_created|kube_daemonset_status_number_available|kube_deployment_status_replicas_unavailable|kube_deployment_status_condition|kube_replicaset_status_ready_replicas|kube_replicaset_status_replicas|kube_statefulset_replicas|kube_statefulset_status_replicas|kube_pod_start_time|kube_pod_status_reason|kube_pod_container_resource_limits|kube_pod_status_scheduled|kube_pod_container_resource_requests|kube_pod_status_container_ready_time|kube_pod_container_status_terminated|kube_pod_container_status_ready|kube_statefulset_status_replicas_updated|kube_statefulset_status_replicas_ready|kube_daemonset_status_desired_number_scheduled|kube_deployment_status_replicas_ready|kube_pod_container_state_started|kube_statefulset_created|kube_daemonset_status_updated_number_scheduled|kube_statefulset_status_replicas_current|kube_daemonset_status_number_ready|kube_pod_container_status_running|kube_pod_created|kube_pod_container_status_restarts_total|kube_daemonset_status_number_unavailable
                   action: keep
               {{- end }}
 


### PR DESCRIPTION
# Changes

- Following `kube-state-metrics` metrics are added as important metrics:
  - `kube_replicaset_status_replicas`
  - `kube_daemonset_status_number_available`
  - `kube_statefulset_status_replicas`
  - `kube_pod_info`