### PR TITLE
Removed filtering and multi-account export for singleton collector

### DIFF
--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -63,7 +63,7 @@ spec:
           fieldPath: metadata.namespace
   {{- if .Values.global.newrelic.enabled }}
     {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
-      {{- if ne $teamInfo.ignore true }}
+      {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") }}
     - name: {{ $teamName }}-endpoint
       value: {{ $.Values.global.newrelic.endpoint }}
         {{- if $teamInfo.licenseKey.secretRef }}
@@ -83,7 +83,7 @@ spec:
     {{- end }}
   {{- else }}
     {{- range $teamName, $teamInfo := .Values.singleton.newrelic.teams }}
-      {{- if ne $teamInfo.ignore true }}
+      {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") }}
     - name: {{ $teamName }}-endpoint
       value: {{ $teamInfo.endpoint }}
         {{- if $teamInfo.licenseKey.secretRef }}
@@ -165,43 +165,6 @@ spec:
           - key: k8s.pod.name
             value: $MY_POD_NAME
             action: upsert
-      {{- if .Values.global.newrelic.enabled }}
-        {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
-          {{- if and (ne $teamInfo.ignore true) (ne (len $teamInfo.namespaces) 0) }}
-      filter/{{ $teamName }}:
-        error_mode: ignore
-        logs:
-          log_record:
-          {{ $conditionForK8sNamespaceName := "" -}}
-          {{- range $index, $namespace := $teamInfo.namespaces -}}
-            {{- if eq $index 0 -}}
-              {{- $conditionForK8sNamespaceName = printf "not IsMatch(resource.attributes[\"k8s.namespace.name\"], \"%s\")" $namespace -}}
-            {{ else }}
-              {{- $conditionForK8sNamespaceName = printf "%s and not IsMatch(resource.attributes[\"k8s.namespace.name\"], \"%s\")" $conditionForK8sNamespaceName $namespace -}}
-            {{- end -}}
-          {{- end -}}
-            - '{{ $conditionForK8sNamespaceName }}'
-          {{- end }}
-        {{- end }}
-      {{- else }}
-        {{- range $teamName, $teamInfo := .Values.singleton.newrelic.teams }}
-          {{- if and (ne $teamInfo.ignore true) (ne (len $teamInfo.namespaces) 0) }}
-      filter/{{ $teamName }}:
-        error_mode: ignore
-        logs:
-          log_record:
-          {{ $conditionForK8sNamespaceName := "" -}}
-          {{- range $index, $namespace := $teamInfo.namespaces -}}
-            {{- if eq $index 0 -}}
-              {{- $conditionForK8sNamespaceName = printf "not IsMatch(resource.attributes[\"k8s.namespace.name\"], \"%s\")" $namespace -}}
-            {{ else }}
-              {{- $conditionForK8sNamespaceName = printf "%s and not IsMatch(resource.attributes[\"k8s.namespace.name\"], \"%s\")" $conditionForK8sNamespaceName $namespace -}}
-            {{- end -}}
-          {{- end -}}
-            - '{{ $conditionForK8sNamespaceName }}'
-          {{- end }}
-        {{- end }}
-      {{- end }}
       memory_limiter:
          check_interval: 1s
          limit_percentage: 80
@@ -214,7 +177,7 @@ spec:
     exporters:
     {{- if .Values.global.newrelic.enabled }}
       {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
-        {{- if ne $teamInfo.ignore true }}
+        {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") }}
       otlp/{{ $teamName }}:
         endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
@@ -225,7 +188,7 @@ spec:
       {{- end }}
     {{- else }}
       {{- range $teamName, $teamInfo := .Values.singleton.newrelic.teams }}
-        {{- if ne $teamInfo.ignore true }}
+        {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") }}
       otlp/{{ $teamName }}:
         endpoint: ${env:{{ $teamName }}-endpoint}
         tls:
@@ -261,7 +224,7 @@ spec:
             # - logging
       {{- if .Values.global.newrelic.enabled }}
         {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
-          {{- if ne $teamInfo.ignore true }}
+          {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") }}
         logs/{{ $teamName }}:
           receivers:
             - k8s_events
@@ -270,9 +233,6 @@ spec:
             - attributes
             - attributes/self
             - memory_limiter
-          {{- if ne (len $teamInfo.namespaces) 0 }}
-            - filter/{{ $teamName }}
-          {{- end }}
             - batch
           exporters:
             - otlp/{{ $teamName }}
@@ -281,7 +241,7 @@ spec:
         {{- end }}
       {{- else }}
         {{- range $teamName, $teamInfo := .Values.singleton.newrelic.teams }}
-          {{- if ne $teamInfo.ignore true }}
+          {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") }}
         logs/{{ $teamName }}:
           receivers:
             - k8s_events
@@ -290,9 +250,6 @@ spec:
             - attributes
             - attributes/self
             - memory_limiter
-          {{- if ne (len $teamInfo.namespaces) 0 }}
-            - filter/{{ $teamName }}
-          {{- end }}
             - batch
           exporters:
             - otlp/{{ $teamName }}

--- a/helm/charts/collectors/templates/singleton-secret.yaml
+++ b/helm/charts/collectors/templates/singleton-secret.yaml
@@ -1,7 +1,7 @@
 {{- if eq .Values.events.enabled true -}}
   {{- if .Values.global.newrelic.enabled -}}
     {{- range $teamName, $teamInfo := .Values.global.newrelic.teams }}
-      {{- if ne $teamInfo.ignore true -}}
+      {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") -}}
         {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret
@@ -16,7 +16,7 @@ data:
     {{- end -}}
   {{- else -}}
     {{- range $teamName, $teamInfo := .Values.singleton.newrelic.teams }}
-      {{- if ne $teamInfo.ignore true -}}
+      {{- if and (ne $teamInfo.ignore true) (eq $teamName "opsteam") -}}
         {{- if and (not $teamInfo.licenseKey.secretRef) $teamInfo.licenseKey.value -}}
 apiVersion: v1
 kind: Secret

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -714,10 +714,16 @@ singleton:
           secretRef: null
             # name: ""
             # key: ""
+        ###################################################################
+        ### Namespaced filtering does not work for events at the moment ###
+        ###################################################################
         # Namespaces to filter the gathered telemetry data
         # -> If nothing is defined, all telemetry data will be sent
-        namespaces: []
+        # namespaces: []
 
+      ###################################################################
+      ### Multi-account export does not work for events at the moment ###
+      ###################################################################
       # # If you want to send the namespaced telemetry data from the
       # # cluster to the accounts of the individual dev teams
       # # comment in below.

--- a/helm/tests/scripts/02_test_helm_outputs.sh
+++ b/helm/tests/scripts/02_test_helm_outputs.sh
@@ -131,7 +131,7 @@ runTests() {
 
   # OTLP exporter for opsteam should be configured
   collectorDaemonsetOpsteamExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDaemonsetName}'")).spec.config' | yq '.exporters.otlp/opsteam')
-  if [[ $collectorDaemonsetOpsteamExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorDaemonsetOpsteamExporterOtlpConfigCheck == "" && $collectorDaemonsetOpsteamExporterOtlpConfigCheck != "null" ]]; then
     echo "Team: opsteam"
     echo "Component: otlpexporter"
     echo "Message: Exporter should be configured but it has not!"
@@ -140,7 +140,7 @@ runTests() {
 
   # OTLP exporter for devteam1 should be configured
   collectorDaemonsetDevteam1ExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDaemonsetName}'")).spec.config' | yq '.exporters.otlp/devteam1')
-  if [[ $collectorDaemonsetDevteam1ExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorDaemonsetDevteam1ExporterOtlpConfigCheck == "" && $collectorDaemonsetDevteam1ExporterOtlpConfigCheck != "null" ]]; then
     echo "Team: devteam1"
     echo "Component: otlpexporter"
     echo "Message: Exporter should be configured but it has not!"
@@ -373,7 +373,7 @@ runTests() {
 
   # OTLP exporter for opsteam should be configured - receiver
   collectorDeploymentReceiverOpsteamExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentReceiverName}'")).spec.config' | yq '.exporters.otlp/opsteam')
-  if [[ $collectorDeploymentReceiverOpsteamExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorDeploymentReceiverOpsteamExporterOtlpConfigCheck == "" && $collectorDeploymentReceiverOpsteamExporterOtlpConfigCheck != "null" ]]; then
     echo "Mode: receiver"
     echo "Team: opsteam"
     echo "Component: otlpexporter"
@@ -383,7 +383,7 @@ runTests() {
 
   # OTLP exporter for devteam1 should be configured - receiver
   collectorDeploymentReceiverDevteam1ExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentReceiverName}'")).spec.config' | yq '.exporters.otlp/devteam1')
-  if [[ $collectorDeploymentReceiverDevteam1ExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorDeploymentReceiverDevteam1ExporterOtlpConfigCheck == "" && $collectorDeploymentReceiverDevteam1ExporterOtlpConfigCheck != "null" ]]; then
     echo "Mode: receiver"
     echo "Team: devteam1"
     echo "Component: otlpexporter"
@@ -412,7 +412,7 @@ runTests() {
 
   # OTLP exporter for opsteam should be configured - sampler
   collectorDeploymentSamplerOpsteamExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentSamplerName}'")).spec.config' | yq '.exporters.otlp/opsteam')
-  if [[ $collectorDeploymentSamplerOpsteamExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorDeploymentSamplerOpsteamExporterOtlpConfigCheck == "" && $collectorDeploymentSamplerOpsteamExporterOtlpConfigCheck != "null" ]]; then
     echo "Mode: sampler"
     echo "Team: opsteam"
     echo "Component: otlpexporter"
@@ -422,7 +422,7 @@ runTests() {
 
   # OTLP exporter for devteam1 should be configured - sampler
   collectorDeploymentSamplerDevteam1ExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentSamplerName}'")).spec.config' | yq '.exporters.otlp/devteam1')
-  if [[ $collectorDeploymentSamplerDevteam1ExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorDeploymentSamplerDevteam1ExporterOtlpConfigCheck == "" && $collectorDeploymentSamplerDevteam1ExporterOtlpConfigCheck != "null" ]]; then
     echo "Mode: sampler"
     echo "Team: devteam1"
     echo "Component: otlpexporter"
@@ -674,7 +674,7 @@ runTests() {
 
   # OTLP exporter for opsteam should be configured
   collectorStatefulsetOpsteamExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorStatefulsetName}'")).spec.config' | yq '.exporters.otlp/opsteam')
-  if [[ $collectorStatefulsetOpsteamExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorStatefulsetOpsteamExporterOtlpConfigCheck == "" && $collectorStatefulsetOpsteamExporterOtlpConfigCheck != "null" ]]; then
     echo "Team: opsteam"
     echo "Component: otlpexporter"
     echo "Message: Exporter should be configured but it has not!"
@@ -683,7 +683,7 @@ runTests() {
 
   # OTLP exporter for devteam1 should be configured
   collectorStatefulsetDevteam1ExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorStatefulsetName}'")).spec.config' | yq '.exporters.otlp/devteam1')
-  if [[ $collectorStatefulsetDevteam1ExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorStatefulsetDevteam1ExporterOtlpConfigCheck == "" && $collectorStatefulsetDevteam1ExporterOtlpConfigCheck != "null" ]]; then
     echo "Team: devteam1"
     echo "Component: otlpexporter"
     echo "Message: Exporter should be configured but it has not!"

--- a/helm/tests/scripts/02_test_helm_outputs.sh
+++ b/helm/tests/scripts/02_test_helm_outputs.sh
@@ -782,11 +782,11 @@ runTests() {
     exit 1
   fi
 
-  # Secret for devteam1 should be created
+  # Secret for devteam1 should not be created
   secretSingletonDevteam1Check=$(echo "$helmTemplate" | yq 'select((.kind == "Secret") and (.metadata.name == "'${secretSingletonDevteam1Name}'")).metadata.name')
-  if [[ $secretSingletonDevteam1Check != $secretSingletonDevteam1Name ]]; then
+  if [[ $secretSingletonDevteam1Check != "" ]]; then
     echo "Team: devteam1"
-    echo "Message: Secret should have been created but it has not!"
+    echo "Message: Secret should not have been created but it has!"
     exit 1
   fi
 
@@ -813,11 +813,11 @@ runTests() {
     exit 1
   fi
 
-  # Secret for devteam1 should be assigned
+  # Secret for devteam1 should not be assigned
   collectorSingletonDevteam1EnvVarCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.env[] | select(.valueFrom.secretKeyRef.name == "'${secretSingletonDevteam1Name}'").valueFrom.secretKeyRef.name')
-  if [[ $collectorSingletonDevteam1EnvVarCheck != $secretSingletonDevteam1Name ]]; then
+  if [[ $collectorSingletonDevteam1EnvVarCheck != "" ]]; then
     echo "Team: devteam1"
-    echo "Message: Environment variable should have been assigned but it has not!"
+    echo "Message: Environment variable should not have been assigned but it has!"
     exit 1
   fi
 
@@ -836,9 +836,9 @@ runTests() {
   echo -e "\n---"
   echo "Message: Testing collector processors configuration..."
 
-  # Filter processor for devteam1 should be configured
+  # Filter processor for devteam1 should not be configured
   collectorSingletonDevteam1ProcessorFilterConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.config' | yq '.processors.filter/devteam1')
-  if [[ $collectorSingletonDevteam1ProcessorFilterConfigCheck == "" ]]; then
+  if [[ $collectorSingletonDevteam1ProcessorFilterConfigCheck != "null" ]]; then
     echo "Team: devteam1"
     echo "Component: filterprocessor"
     echo "Processor should be configured but it has not!"
@@ -863,19 +863,19 @@ runTests() {
 
   # OTLP exporter for opsteam should be configured
   collectorSingletonOpsteamExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.config' | yq '.exporters.otlp/opsteam')
-  if [[ $collectorSingletonOpsteamExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorSingletonOpsteamExporterOtlpConfigCheck == "" && $collectorSingletonOpsteamExporterOtlpConfigCheck != "null" ]]; then
     echo "Team: opsteam"
     echo "Component: otlpexporter"
     echo "Message: Exporter should be configured but it has not!"
     exit 1
   fi
 
-  # OTLP exporter for devteam1 should be configured
+  # OTLP exporter for devteam1 should not be configured
   collectorSingletonDevteam1ExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.config' | yq '.exporters.otlp/devteam1')
-  if [[ $collectorSingletonDevteam1ExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorSingletonDevteam1ExporterOtlpConfigCheck != "null" ]]; then
     echo "Team: devteam1"
     echo "Component: otlpexporter"
-    echo "Message: Exporter should be configured but it has not!"
+    echo "Message: Exporter should not be configured but it has!"
     exit 1
   fi
 
@@ -905,33 +905,33 @@ runTests() {
     exit 1
   fi
 
-  # Pipeline filter processor for devteam1 should be configured
+  # Pipeline filter processor for devteam1 should not be configured
   collectorSingletonDevteam1PipelineProcessorFilterConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.config' | yq '.service.pipelines.logs/devteam1.processors[]' | yq 'select("filter/devteam1")')
-  if [[ $collectorSingletonDevteam1PipelineProcessorFilterConfigCheck == "" ]]; then
+  if [[ $collectorSingletonDevteam1PipelineProcessorFilterConfigCheck != "" ]]; then
     echo "Team: devteam1"
     echo "Component: filterprocessor"
     echo "Telemetry: logs"
-    echo "Message: Pipeline should be configured but it has not!"
+    echo "Message: Pipeline should not be configured but it has!"
     exit 1
   fi
 
-  # Pipeline otlp exporter for devteam1 should be configured
+  # Pipeline otlp exporter for devteam1 should not be configured
   collectorSingletonDevteam1PipelineExporterOtlpConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.config' | yq '.service.pipelines.logs/devteam1.exporters[]' | yq 'select("otlp/devteam1")')
-  if [[ $collectorSingletonDevteam1PipelineExporterOtlpConfigCheck == "" ]]; then
+  if [[ $collectorSingletonDevteam1PipelineExporterOtlpConfigCheck != "" ]]; then
     echo "Team: devteam1"
     echo "Component: otlpexporter"
     echo "Telemetry: logs"
-    echo "Message: Pipeline should be configured but it has not!"
+    echo "Message: Pipeline should not be configured but it has!"
     exit 1
   fi
 
-  # Pipeline filter processor for devteam2 should be configured
+  # Pipeline filter processor for devteam2 should not be configured
   collectorSingletonDevteam2PipelineProcessorFilterConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorSingletonName}'")).spec.config' | yq '.service.pipelines.logs/devteam2.processors[]' | yq 'select("filter/devteam2")')
   if [[ $collectorSingletonDevteam2PipelineProcessorFilterConfigCheck != "" ]]; then
     echo "Team: devteam2"
     echo "Component: filterprocessor"
     echo "Telemetry: logs"
-    echo "Message: Pipeline should be configured but it has not!"
+    echo "Message: Pipeline should not be configured but it has!"
     exit 1
   fi
 


### PR DESCRIPTION
# Changes

- Namespace-based filtering is removed from `singleton` collector.
- Multi-account export is removed from `singleton` collector.
- Helm output tests are updated.