### PR TITLE
Fixed indentation typo in the loop

### DIFF
--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -137,7 +137,7 @@ spec:
                   {{ else }}
                     {{- $metrics = printf "%s|%s" $metrics $metric -}}
                   {{- end -}}
-                {{- end -}}
+                {{- end }}
               metric_relabel_configs:
                 - source_labels: [__name__]
                   separator: ;

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -122,7 +122,7 @@ spec:
                   {{ else }}
                     {{- $metrics = printf "%s|%s" $metrics $metric -}}
                   {{- end -}}
-                {{- end -}}
+                {{- end }}
               metric_relabel_configs:
                 - source_labels: [__name__]
                   separator: ;

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -122,7 +122,7 @@ spec:
                   {{ else }}
                     {{- $metrics = printf "%s|%s" $metrics $metric -}}
                   {{- end -}}
-                {{- end -}}
+                {{- end }}
               metric_relabel_configs:
                 - source_labels: [__name__]
                   separator: ;

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -122,7 +122,7 @@ spec:
                   {{ else }}
                     {{- $metrics = printf "%s|%s" $metrics $metric -}}
                   {{- end -}}
-                {{- end -}}
+                {{- end }}
               metric_relabel_configs:
                 - source_labels: [__name__]
                   separator: ;


### PR DESCRIPTION
# Changes

- `{{- end -}}` instead of `{{- end }}` at the end of the `importantMetrics` loop is fixed.