### PR TITLE
Switched Target Allocator strategies

### DIFF
--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -26,6 +26,8 @@ spec:
   targetAllocator:
     enabled: true
     serviceAccount: {{ include "nrotel.statefulsetName" . }}
+    filterStrategy: {{ .Values.statefulset.targetAllocator.filterStrategy }}
+    allocationStrategy: {{ .Values.statefulset.targetAllocator.allocationStrategy }}
     prometheusCR:
       enabled: false
 

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -611,6 +611,18 @@ statefulset:
       cpu: 256m
       memory: 512Mi
 
+  # Target allocator
+  targetAllocator:
+    # Strategy to filter the discovered targets before distributing them across collectors.
+    # Options:
+    # - relabel-config (default)
+    filterStrategy: relabel-config
+    # Strategy to distribute targets across collectors.
+    # Options:
+    # - consistent-hashing (default)
+    # - least-weighted
+    allocationStrategy: consistent-hashing
+
   # Specific Prometheus configuration
   prometheus:
     # Collector scraping its own metrics


### PR DESCRIPTION
# Changes

- Target Allocator strategies are exposed as Helm variables.
- Default allocation strategy is set as `consistent-hashing`.
- Default filtering strategy is set as `relabel-config`.