### PR TITLE
Improved memory usage of collectors

### DIFF
--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -150,7 +150,6 @@ spec:
       {{- end }}
 
     processors:
-      cumulativetodelta:
       k8sattributes:
         extract:
           metadata:
@@ -272,7 +271,6 @@ spec:
             - prometheus/self
           processors:
             - memory_limiter
-            - cumulativetodelta
             - k8sattributes
             - attributes
             - attributes/self

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -271,11 +271,11 @@ spec:
           receivers:
             - prometheus/self
           processors:
+            - memory_limiter
             - cumulativetodelta
             - k8sattributes
             - attributes
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/opsteam
@@ -287,9 +287,9 @@ spec:
           receivers:
             - filelog
           processors:
+            - memory_limiter
             - k8sattributes
             - attributes
-            - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}
@@ -306,9 +306,9 @@ spec:
           receivers:
             - filelog
           processors:
+            - memory_limiter
             - k8sattributes
             - attributes
-            - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -261,7 +261,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 20
+        size_in_percentage: 40
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -255,7 +255,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 20
+        size_in_percentage: 40
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -136,7 +136,6 @@ spec:
           http:
 
     processors:
-      cumulativetodelta:
       k8sattributes:
         extract:
           metadata:
@@ -266,7 +265,6 @@ spec:
             - prometheus/self
           processors:
             - memory_limiter
-            - cumulativetodelta
             - k8sattributes
             - attributes
             - attributes/self
@@ -282,7 +280,6 @@ spec:
             - otlp
           processors:
             - memory_limiter
-            - cumulativetodelta
             - k8sattributes
             - attributes
           {{- if ne (len $teamInfo.namespaces) 0 }}
@@ -302,7 +299,6 @@ spec:
             - otlp
           processors:
             - memory_limiter
-            - cumulativetodelta
             - k8sattributes
             - attributes
           {{- if ne (len $teamInfo.namespaces) 0 }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -265,11 +265,11 @@ spec:
           receivers:
             - prometheus/self
           processors:
+            - memory_limiter
             - cumulativetodelta
             - k8sattributes
             - attributes
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/opsteam
@@ -281,10 +281,10 @@ spec:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - cumulativetodelta
             - k8sattributes
             - attributes
-            - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}
@@ -301,10 +301,10 @@ spec:
           receivers:
             - otlp
           processors:
+            - memory_limiter
             - cumulativetodelta
             - k8sattributes
             - attributes
-            - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -136,7 +136,6 @@ spec:
           http:
 
     processors:
-      cumulativetodelta:
       attributes:
         actions:
           - key: k8s.cluster.name
@@ -242,7 +241,6 @@ spec:
             - prometheus/self
           processors:
             - memory_limiter
-            - cumulativetodelta
             - attributes
             - attributes/self
             - batch

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -241,10 +241,10 @@ spec:
           receivers:
             - prometheus/self
           processors:
+            - memory_limiter
             - cumulativetodelta
             - attributes
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/opsteam
@@ -256,8 +256,8 @@ spec:
           receivers:
             - otlp
           processors:
-            - attributes
             - memory_limiter
+            - attributes
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}
@@ -274,8 +274,8 @@ spec:
           receivers:
             - otlp
           processors:
-            - attributes
             - memory_limiter
+            - attributes
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -231,7 +231,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 20
+        size_in_percentage: 40
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -133,7 +133,6 @@ spec:
       k8s_events:
 
     processors:
-      cumulativetodelta:
       k8sattributes:
         extract:
           metadata:
@@ -218,7 +217,6 @@ spec:
             - prometheus/self
           processors:
             - memory_limiter
-            - cumulativetodelta
             - k8sattributes
             - attributes
             - attributes/self

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -207,7 +207,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 20
+        size_in_percentage: 40
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -217,11 +217,11 @@ spec:
           receivers:
             - prometheus/self
           processors:
+            - memory_limiter
             - cumulativetodelta
             - k8sattributes
             - attributes
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/opsteam
@@ -233,10 +233,10 @@ spec:
           receivers:
             - k8s_events
           processors:
+            - memory_limiter
             - k8sattributes
             - attributes
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/{{ $teamName }}
@@ -250,10 +250,10 @@ spec:
           receivers:
             - k8s_events
           processors:
+            - memory_limiter
             - k8sattributes
             - attributes
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/{{ $teamName }}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -701,13 +701,13 @@ spec:
           receivers:
             - prometheus/self
           processors:
+            - memory_limiter
             - cumulativetodelta
             - resourcedetection
             - k8sattributes
             - attributes
             - resource
             - attributes/self
-            - memory_limiter
             - batch
           exporters:
             - otlp/opsteam
@@ -719,12 +719,12 @@ spec:
           receivers:
             - prometheus
           processors:
+            - memory_limiter
             - cumulativetodelta
             - resourcedetection
             - k8sattributes
             - attributes
             - resource
-            - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}
@@ -741,12 +741,12 @@ spec:
           receivers:
             - prometheus
           processors:
+            - memory_limiter
             - cumulativetodelta
             - resourcedetection
             - k8sattributes
             - attributes
             - resource
-            - memory_limiter
           {{- if ne (len $teamInfo.namespaces) 0 }}
             - filter/{{ $teamName }}
           {{- end }}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -691,7 +691,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 20
+        size_in_percentage: 40
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -525,7 +525,6 @@ spec:
             {{ end }}
 
     processors:
-      cumulativetodelta:
       resourcedetection:
         detectors: [env, azure]
         azure:
@@ -702,7 +701,6 @@ spec:
             - prometheus/self
           processors:
             - memory_limiter
-            - cumulativetodelta
             - resourcedetection
             - k8sattributes
             - attributes
@@ -720,7 +718,6 @@ spec:
             - prometheus
           processors:
             - memory_limiter
-            - cumulativetodelta
             - resourcedetection
             - k8sattributes
             - attributes
@@ -742,7 +739,6 @@ spec:
             - prometheus
           processors:
             - memory_limiter
-            - cumulativetodelta
             - resourcedetection
             - k8sattributes
             - attributes


### PR DESCRIPTION
# Changes

- `ballastextension` is set to `40%`.
- `memorylimiterprocessor` is put to be the first processor right after the receivers.
- `cumulativetodeltaprocessor` is removed.
