### PR TITLE
Whitelisted more memory metrics for cadvisor

### DIFF
--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -672,6 +672,9 @@ statefulset:
       importantMetrics: []
         # - container_cpu_usage_seconds_total
         # - container_memory_usage_bytes
+        # - container_memory_working_set_bytes
+        # - container_memory_rss
+        # - container_memory_swap
         # - container_fs_reads_total
         # - container_fs_writes_total
         # - container_network_receive_bytes_total

--- a/monitoring/docs/understanding_prometheus_metrics.md
+++ b/monitoring/docs/understanding_prometheus_metrics.md
@@ -73,6 +73,9 @@ Important metrics:
 
 - container_cpu_usage_seconds_total
 - container_memory_usage_bytes
+- container_memory_working_set_bytes
+- container_memory_rss
+- container_memory_swap
 - container_fs_reads_total
 - container_fs_writes_total
 - container_network_receive_bytes_total


### PR DESCRIPTION
# Changes

- The following memory metrics are marked as important:
  - `container_memory_working_set_bytes`
  - `container_memory_rss`
  - `container_memory_swap`