### PR TITLE
Fixed target allocator naming

### DIFF
--- a/helm/charts/collectors/templates/_helpers.tpl
+++ b/helm/charts/collectors/templates/_helpers.tpl
@@ -66,6 +66,13 @@ Set name for deployment collectors.
 {{- end -}}
 
 {{/*
+Set name for target allocator.
+*/}}
+{{- define "nrotel.targetAllocatorName" -}}
+{{- printf "%s-%s" (include "nrotel.name" .) "sts-targetallocator" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Set name for daemonset collectors.
 */}}
 {{- define "nrotel.daemonsetName" -}}

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -492,7 +492,7 @@ spec:
                   replacement: $$1:$$2
                 - source_labels: [__meta_kubernetes_service_name]
                   action: keep
-                  regex: {{ printf "%s-sts-targetallocator" .Chart.Name }}
+                  regex: {{ include "nrotel.targetAllocatorName" . }}
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
                   target_label: namespace


### PR DESCRIPTION
# Changes

- Naming of scrape job for Target Allocator (`oteltargetallocators`) is fixed.