### PR TITLE
Exposed memory_ballast extension as variable

### DIFF
--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -260,7 +260,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 40
+        size_in_percentage: {{ .Values.daemonset.extensions.memory_ballast.size_in_percentage }}
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -254,7 +254,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 40
+        size_in_percentage: {{ .Values.deployment.extensions.memory_ballast.receiver.size_in_percentage }}
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -230,7 +230,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 40
+        size_in_percentage: {{ .Values.deployment.extensions.memory_ballast.sampler.size_in_percentage }}
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -206,7 +206,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 40
+        size_in_percentage: {{ .Values.singleton.extensions.memory_ballast.size_in_percentage }}
 
     service:
       extensions:

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -690,7 +690,7 @@ spec:
 
     extensions:
       memory_ballast:
-        size_in_percentage: 40
+        size_in_percentage: {{ .Values.singleton.extensions.memory_ballast.size_in_percentage }}
 
     service:
       extensions:

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -219,6 +219,19 @@ deployment:
           # - otelcol_exporter_refused_spans
           # - otelcol_exporter_refused_log_records
 
+  # Specific collector extension configuration
+  extensions:
+    # Memory ballast
+    memory_ballast:
+      # Receiver collectors
+      receiver:
+        # Size in percentage
+        size_in_percentage: 20
+      # Sampler collectors
+      sampler:
+        # Size in percentage
+        size_in_percentage: 20
+
   # New Relic account configuration
   # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
@@ -363,6 +376,13 @@ daemonset:
         # - otelcol_exporter_refused_metric_points
         # - otelcol_exporter_refused_spans
         # - otelcol_exporter_refused_log_records
+
+  # Specific collector extension configuration
+  extensions:
+    # Memory ballast
+    memory_ballast:
+      # Size in percentage
+      size_in_percentage: 20
 
   # Log tailing & parsing rules
   filelog:
@@ -823,6 +843,13 @@ statefulset:
             action: replace
             target_label: node
 
+  # Specific collector extension configuration
+  extensions:
+    # Memory ballast
+    memory_ballast:
+      # Size in percentage
+      size_in_percentage: 20
+
   # New Relic account configuration
   # -> If the global New Relic configuration is enabled, this section will be ignored
   newrelic:
@@ -1014,6 +1041,13 @@ singleton:
         # - otelcol_exporter_refused_metric_points
         # - otelcol_exporter_refused_spans
         # - otelcol_exporter_refused_log_records
+
+  # Specific collector extension configuration
+  extensions:
+    # Memory ballast
+    memory_ballast:
+      # Size in percentage
+      size_in_percentage: 20
 
   # New Relic account configuration
   # -> If the global New Relic configuration is enabled, this section will be ignored


### PR DESCRIPTION
# Changes

- `memory_ballast` extension is exposed as variable.
- It's default value is set to `20`.