### PR TITLE
Renamed main collector variables

### DIFF
--- a/helm/charts/collectors/templates/NOTES.txt
+++ b/helm/charts/collectors/templates/NOTES.txt
@@ -1,13 +1,13 @@
 #######################################
 ### Enjoy your OTel K8s experience! ###
 #######################################
-{{ if and (not .Values.traces.enabled) (not .Values.logs.enabled) (not .Values.metrics.enabled) (not .Values.events.enabled) -}}
+{{ if and (not .Values.deployment.enabled) (not .Values.daemonset.enabled) (not .Values.statefulset.enabled) (not .Values.singleton.enabled) -}}
   {{ fail "ERROR: At least one of the following must be enabled: traces, logs, metrics & events!" }}
 {{- end -}}
 {{ if not .Values.clusterName -}}
   {{ fail "ERROR: Cluster name should be defined!" }}
 {{- end -}}
-{{ if .Values.traces.enabled -}}
+{{ if .Values.deployment.enabled -}}
   {{- if and (not .Values.global.newrelic.enabled) (not .Values.deployment.newrelic.teams) -}}
     {{ fail "ERROR [DEPLOYMENT]: You have enabled traces but haven't defined any New Relic account neither in the global section nor in the deployment section to send the data to!" }}
   {{- end -}}
@@ -62,7 +62,7 @@
   {{- end }}
 Traces are enabled. Deployments of OTel collectors are deployed.
 {{- end -}}
-{{ if .Values.logs.enabled -}}
+{{ if .Values.daemonset.enabled -}}
   {{- if and (not .Values.global.newrelic.enabled) (not .Values.daemonset.newrelic.teams) -}}
     {{ fail "ERROR [DAEMONSET]: You have enabled logs but haven't defined any New Relic account neither in the global section nor in the daemonset section to send the data to!" }}
   {{- end -}}
@@ -117,7 +117,7 @@ Traces are enabled. Deployments of OTel collectors are deployed.
   {{- end }}
 Logs are enabled. Daemonset of OTel collectors are deployed.
 {{- end -}}
-{{ if .Values.metrics.enabled }}
+{{ if .Values.statefulset.enabled }}
   {{- if and (not .Values.global.newrelic.enabled) (not .Values.statefulset.newrelic.teams) -}}
     {{ fail "ERROR [STATEFULSET]: You have enabled metrics but haven't defined any New Relic account neither in the global section nor in the statefulet section to send the data to!" }}
   {{- end -}}
@@ -172,7 +172,7 @@ Logs are enabled. Daemonset of OTel collectors are deployed.
   {{- end }}
 Metrics are enabled. Statefulset of OTel collectors are deployed.
 {{- end }}
-{{ if .Values.events.enabled -}}
+{{ if .Values.singleton.enabled -}}
   {{- if and (not .Values.global.newrelic.enabled) (not .Values.singleton.newrelic.teams) -}}
     {{ fail "ERROR [SINGLETON]: You have enabled events but haven't defined any New Relic account neither in the global section nor in the singleton section to send the data to!" }}
   {{- end -}}

--- a/helm/charts/collectors/templates/daemonset-clusterrole.yaml
+++ b/helm/charts/collectors/templates/daemonset-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.logs.enabled true -}}
+{{- if eq .Values.daemonset.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/charts/collectors/templates/daemonset-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/daemonset-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.logs.enabled true -}}
+{{- if eq .Values.daemonset.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.logs.enabled true -}}
+{{- if eq .Values.daemonset.enabled true -}}
 {{- $teams := include "daemonsetTeamConfig" . | fromYaml }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/helm/charts/collectors/templates/daemonset-secret.yaml
+++ b/helm/charts/collectors/templates/daemonset-secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.logs.enabled true -}}
+{{- if eq .Values.daemonset.enabled true -}}
 {{- $teams := include "daemonsetTeamConfig" . | fromYaml }}
   {{- range $teamName, $teamInfo := $teams }}
     {{- if ne $teamInfo.ignore true -}}

--- a/helm/charts/collectors/templates/daemonset-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/daemonset-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.logs.enabled true -}}
+{{- if eq .Values.daemonset.enabled true -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/charts/collectors/templates/deployment-clusterrole.yaml
+++ b/helm/charts/collectors/templates/deployment-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.traces.enabled true -}}
+{{- if eq .Values.deployment.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/charts/collectors/templates/deployment-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/deployment-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.traces.enabled true -}}
+{{- if eq .Values.deployment.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.traces.enabled true -}}
+{{- if eq .Values.deployment.enabled true -}}
 {{- $teams := include "deploymentTeamConfig" . | fromYaml }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.traces.enabled true -}}
+{{- if eq .Values.deployment.enabled true -}}
 {{- $teams := include "deploymentTeamConfig" . | fromYaml }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/helm/charts/collectors/templates/deployment-secret.yaml
+++ b/helm/charts/collectors/templates/deployment-secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.traces.enabled true -}}
+{{- if eq .Values.deployment.enabled true -}}
 {{- $teams := include "deploymentTeamConfig" . | fromYaml }}
   {{- range $teamName, $teamInfo := $teams }}
     {{- if ne $teamInfo.ignore true -}}

--- a/helm/charts/collectors/templates/deployment-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/deployment-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.traces.enabled true -}}
+{{- if eq .Values.deployment.enabled true -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/charts/collectors/templates/singleton-clusterrole.yaml
+++ b/helm/charts/collectors/templates/singleton-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.events.enabled true -}}
+{{- if eq .Values.singleton.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/charts/collectors/templates/singleton-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/singleton-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.events.enabled true -}}
+{{- if eq .Values.singleton.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.events.enabled true -}}
+{{- if eq .Values.singleton.enabled true -}}
 {{- $teams := include "singletonTeamConfig" . | fromYaml }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/helm/charts/collectors/templates/singleton-secret.yaml
+++ b/helm/charts/collectors/templates/singleton-secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.events.enabled true -}}
+{{- if eq .Values.singleton.enabled true -}}
 {{- $teams := include "statefulsetTeamConfig" . | fromYaml }}
   {{- range $teamName, $teamInfo := $teams }}
     {{- if ne $teamInfo.ignore true -}}

--- a/helm/charts/collectors/templates/singleton-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/singleton-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.events.enabled true -}}
+{{- if eq .Values.singleton.enabled true -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/charts/collectors/templates/statefulset-clusterrole.yaml
+++ b/helm/charts/collectors/templates/statefulset-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.metrics.enabled true -}}
+{{- if eq .Values.statefulset.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/charts/collectors/templates/statefulset-clusterrolebinding.yaml
+++ b/helm/charts/collectors/templates/statefulset-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.metrics.enabled true -}}
+{{- if eq .Values.statefulset.enabled true -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.metrics.enabled true -}}
+{{- if eq .Values.statefulset.enabled true -}}
 {{- $teams := include "statefulsetTeamConfig" . | fromYaml }}
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/helm/charts/collectors/templates/statefulset-secret.yaml
+++ b/helm/charts/collectors/templates/statefulset-secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.metrics.enabled true -}}
+{{- if eq .Values.statefulset.enabled true -}}
 {{- $teams := include "statefulsetTeamConfig" . | fromYaml }}
   {{- range $teamName, $teamInfo := $teams }}
     {{- if ne $teamInfo.ignore true -}}

--- a/helm/charts/collectors/templates/statefulset-serviceaccount.yaml
+++ b/helm/charts/collectors/templates/statefulset-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.metrics.enabled true -}}
+{{- if eq .Values.statefulset.enabled true -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -6,20 +6,6 @@ nameOverride: null
 # Cluster name
 clusterName: ""
 
-### Flags ###
-# Logs
-logs:
-  enabled: true
-# Traces
-traces:
-  enabled: true
-# Metrics
-metrics:
-  enabled: true
-# Events
-events:
-  enabled: true
-
 ### GLOBAL CONFIG ###
 # Global config for ease of use to apply to all collector types.
 global:
@@ -102,6 +88,9 @@ global:
 
 # Both collectors can be scaled out/in independently from each other
 deployment:
+
+  # Flag to enable
+  enabled: true
 
   # Image
   image:
@@ -347,6 +336,9 @@ deployment:
 # applications running on the cluster.
 daemonset:
 
+  # Flag to enable
+  enabled: true
+
   # Image
   image:
     # Repository
@@ -587,6 +579,9 @@ daemonset:
 # This configuration is responsible for scraping the metrics from the
 # various endpoints within the cluster.
 statefulset:
+
+  # Flag to enable
+  enabled: true
 
   # Image
   image:
@@ -1011,6 +1006,9 @@ statefulset:
 # This configuration is responsible for scraping the events from the
 # Kube-API-Server.
 singleton:
+
+  # Flag to enable
+  enabled: true
 
   # Image
   image:

--- a/helm/tests/scripts/01_test_helm_inputs.sh
+++ b/helm/tests/scripts/01_test_helm_inputs.sh
@@ -52,10 +52,10 @@ if [[ $case == "02" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -81,11 +81,11 @@ if [[ $case == "03" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=true \
+    --set deployment.enabled=true \
     --set deployment.newrelic.teams=null \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -109,11 +109,11 @@ if [[ $case == "04" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
     --set daemonset.newrelic.teams=null \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -137,11 +137,11 @@ if [[ $case == "05" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
     --set statefulset.newrelic.teams=null \
-    --set events.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -165,10 +165,10 @@ if [[ $case == "06" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     --set singleton.newrelic.teams=null \
     "../../charts/collectors" \
     2>&1)
@@ -196,10 +196,10 @@ if [[ $case == "07" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="INVALID_ENDPOINT" \
-    --set traces.enabled=true \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=true \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -224,10 +224,10 @@ if [[ $case == "08" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="INVALID_ENDPOINT" \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -252,10 +252,10 @@ if [[ $case == "09" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="INVALID_ENDPOINT" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -280,10 +280,10 @@ if [[ $case == "10" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="INVALID_ENDPOINT" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     "../../charts/collectors" \
     2>&1)
 
@@ -309,11 +309,11 @@ if [[ $case == "11" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=true \
+    --set deployment.enabled=true \
     --set deployment.newrelic.teams.opsteam.endpoint="INVALID_ENDPOINT" \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -337,11 +337,11 @@ if [[ $case == "12" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
     --set daemonset.newrelic.teams.opsteam.endpoint="INVALID_ENDPOINT" \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -365,11 +365,11 @@ if [[ $case == "13" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
     --set statefulset.newrelic.teams.opsteam.endpoint="INVALID_ENDPOINT" \
-    --set events.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -393,10 +393,10 @@ if [[ $case == "14" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     --set singleton.newrelic.teams.opsteam.endpoint="INVALID_ENDPOINT" \
     "../../charts/collectors" \
     2>&1)
@@ -424,10 +424,10 @@ if [[ $case == "15" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
-    --set traces.enabled=true \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=true \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -452,10 +452,10 @@ if [[ $case == "16" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -480,11 +480,11 @@ if [[ $case == "17" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
     --set statefulset.newrelic.opsteam.endpoint="https://otlp.nr-data.net" \
-    --set events.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -509,10 +509,10 @@ if [[ $case == "18" ]]; then
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     --set singleton.newrelic.opsteam.endpoint="https://otlp.nr-data.net" \
     "../../charts/collectors" \
     2>&1)
@@ -539,11 +539,11 @@ if [[ $case == "19" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=true \
+    --set deployment.enabled=true \
     --set deployment.newrelic.opsteam.endpoint="https://otlp.nr-data.net" \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -566,11 +566,11 @@ if [[ $case == "20" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
     --set daemonset.newrelic.opsteam.endpoint="https://otlp.nr-data.net" \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -593,11 +593,11 @@ if [[ $case == "21" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
     --set statefulset.newrelic.opsteam.endpoint="https://otlp.nr-data.net" \
-    --set events.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -620,10 +620,10 @@ if [[ $case == "22" ]]; then
     --create-namespace \
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     --set singleton.newrelic.opsteam.endpoint="https://otlp.nr-data.net" \
     "../../charts/collectors" \
     2>&1)
@@ -652,10 +652,10 @@ if [[ $case == "23" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set traces.enabled=true \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=true \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -681,10 +681,10 @@ if [[ $case == "24" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -710,10 +710,10 @@ if [[ $case == "25" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -739,10 +739,10 @@ if [[ $case == "26" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     "../../charts/collectors" \
     2>&1)
 
@@ -768,12 +768,12 @@ if [[ $case == "27" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=true \
+    --set deployment.enabled=true \
     --set deployment.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set deployment.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -797,12 +797,12 @@ if [[ $case == "28" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
     --set daemonset.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set daemonset.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -826,12 +826,12 @@ if [[ $case == "29" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
     --set statefulset.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set statefulset.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
-    --set events.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -855,10 +855,10 @@ if [[ $case == "30" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     --set singleton.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set singleton.newrelic.teams.opsteam.licenseKey.secretRef.key="key" \
     "../../charts/collectors" \
@@ -888,10 +888,10 @@ if [[ $case == "31" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set traces.enabled=true \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=true \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -917,10 +917,10 @@ if [[ $case == "32" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -946,10 +946,10 @@ if [[ $case == "33" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
-    --set events.enabled=false \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -975,10 +975,10 @@ if [[ $case == "34" ]]; then
     --set global.newrelic.enabled=true \
     --set global.newrelic.endpoint="https://otlp.nr-data.net" \
     --set global.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     "../../charts/collectors" \
     2>&1)
 
@@ -1004,12 +1004,12 @@ if [[ $case == "35" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=true \
+    --set deployment.enabled=true \
     --set deployment.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set deployment.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -1033,12 +1033,12 @@ if [[ $case == "36" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=true \
     --set daemonset.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set daemonset.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set metrics.enabled=false \
-    --set events.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -1062,12 +1062,12 @@ if [[ $case == "37" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=true \
     --set statefulset.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set statefulset.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
-    --set events.enabled=false \
+    --set singleton.enabled=false \
     "../../charts/collectors" \
     2>&1)
 
@@ -1091,10 +1091,10 @@ if [[ $case == "38" ]]; then
     --namespace ${otelcollectors[namespace]} \
     --set clusterName=$clusterName \
     --set global.newrelic.enabled=false \
-    --set traces.enabled=false \
-    --set logs.enabled=false \
-    --set metrics.enabled=false \
-    --set events.enabled=true \
+    --set deployment.enabled=false \
+    --set daemonset.enabled=false \
+    --set statefulset.enabled=false \
+    --set singleton.enabled=true \
     --set singleton.newrelic.teams.opsteam.endpoint="https://otlp.nr-data.net" \
     --set singleton.newrelic.teams.opsteam.licenseKey.secretRef.name="name" \
     "../../charts/collectors" \


### PR DESCRIPTION
# Changes

- Main collector enabling variables are renamed.
  - `traces.enabled -> deployment.enabled`
  - `logs.enabled -> daemonset.enabled`
  - `metrics.enabled -> statefulset.enabled`
  - `events.enabled -> singleton.enabled`