### PR TITLE
Implemented flags for deployment receiver pipelines

### DIFF
--- a/.github/workflows/validate_helm_output.yml
+++ b/.github/workflows/validate_helm_output.yml
@@ -6,11 +6,13 @@ on:
       - ".github/workflows/validate_helm_output.yml"
       - "helm/charts/**"
       - "helm/tests/scripts/02_test_helm_outputs.sh"
+      - "helm/tests/scripts/03_test_helm_outputs_dep_rec_pipeline.sh"
   pull_request:
     paths:
       - ".github/workflows/validate_helm_output.yml"
       - "helm/charts/**"
       - "helm/tests/scripts/02_test_helm_outputs.sh"
+      - "helm/tests/scripts/03_test_helm_outputs_dep_rec_pipeline.sh"
 
 jobs:
   validate-helm-output:
@@ -40,3 +42,23 @@ jobs:
       - name: ${{ matrix.cases.name }}
         shell: bash
         run: cd ./helm/tests/scripts && bash 02_test_helm_outputs.sh --case ${{ matrix.cases.id }}
+
+  validate-helm-output_dep_rec_pipeline:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: "v3.11.1"
+
+      - name: Update Helm dependencies
+        shell: bash
+        run: helm dependency update ./helm/charts/collectors
+  
+      - name: Check receiver deployment pipeline flags
+        shell: bash
+        run: cd ./helm/tests/scripts && bash 03_test_helm_outputs_dep_rec_pipeline.sh

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -248,8 +248,9 @@ spec:
             - otlphttp/opsteam
             # - logging
 
-        {{- range $teamName, $teamInfo := $teams }}
-          {{- if ne $teamInfo.ignore true }}
+        {{- if eq .Values.deployment.receiverPipeline.metrics.enabled true }}
+          {{- range $teamName, $teamInfo := $teams }}
+            {{- if ne $teamInfo.ignore true }}
         metrics/{{ $teamName }}:
           receivers:
             - otlp
@@ -264,9 +265,11 @@ spec:
           exporters:
             - otlphttp/{{ $teamName }}
             # - logging
+            {{- end }}
           {{- end }}
         {{- end }}
 
+        {{- if eq .Values.deployment.receiverPipeline.traces.enabled true }}
         traces:
           receivers:
             - otlp
@@ -278,9 +281,11 @@ spec:
           exporters:
             - loadbalancing
             # - logging
+        {{- end }}
 
-        {{- range $teamName, $teamInfo := $teams }}
-          {{- if ne $teamInfo.ignore true }}
+        {{- if eq .Values.deployment.receiverPipeline.logs.enabled true }}
+          {{- range $teamName, $teamInfo := $teams }}
+            {{- if ne $teamInfo.ignore true }}
         logs/{{ $teamName }}:
           receivers:
             - otlp
@@ -295,6 +300,7 @@ spec:
           exporters:
             - otlphttp/{{ $teamName }}
             # - logging
+            {{- end }}
           {{- end }}
         {{- end }}
 

--- a/helm/charts/collectors/values.yaml
+++ b/helm/charts/collectors/values.yaml
@@ -203,6 +203,21 @@ deployment:
       # Target MEM utilization to keep amongst the replicas
       targetMemoryUtilization: 70
 
+  # Receiver pipeline flags
+  receiverPipeline:
+    # Metrics
+    metrics:
+      # Flag to enable
+      enabled: true
+    # Traces
+    traces:
+      # Flag to enable
+      enabled: true
+    # Logs
+    logs:
+      # Flag to enable
+      enabled: true
+
   # Specific Prometheus configuration
   prometheus:
     # Receiver collectors

--- a/helm/tests/README.md
+++ b/helm/tests/README.md
@@ -139,11 +139,11 @@ The following tests are implemented to be triggered by the Github workflow on [`
 
 The expected outcome is as follows:
 
-| Operation                                         | `opsteam` | `devteam1` | `devteam2` |
-| ------------------------------------------------- | --------- | ---------- | ---------- |
-| Secret creation                                   | ✅        | ✅         | ❌         |
-| Collector secret environment variables assignment | ✅        | ✅         | ❌         |
-| Collector processors configuration                | ❌        | ✅         | ❌         |
-| Collector exporter configuration                  | ✅        | ✅         | ❌         |
-| Collector pipeline configuration - processor      | ❌        | ✅         | ❌         |
-| Collector pipeline configuration - exporter       | ✅        | ✅         | ❌         |
+| Operation                                          | `opsteam` | `devteam1` | `devteam2` |
+| -------------------------------------------------- | --------- | ---------- | ---------- |
+| Secret creation                                    | ✅        | ✅         | ❌         |
+| Collector secret environment variables assignment  | ✅        | ✅         | ❌         |
+| Collector filterprocessor configuration            | ❌        | ✅         | ❌         |
+| Collector exporter configuration                   | ✅        | ✅         | ❌         |
+| Collector pipeline configuration - filterprocessor | ❌        | ✅         | ❌         |
+| Collector pipeline configuration - exporter        | ✅        | ✅         | ❌         |

--- a/helm/tests/scripts/02_test_helm_outputs.sh
+++ b/helm/tests/scripts/02_test_helm_outputs.sh
@@ -480,7 +480,7 @@ runTests() {
     exit 1
   fi
 
-  # Pipeline filter processor for devteam2 should be configured - receiver
+  # Pipeline filter processor for devteam2 should not be configured - receiver
   collectorDeploymentReceiverDevteam2PipelineProcessorFilterConfigCheck=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentReceiverName}'")).spec.config' | yq '.service.pipelines.metrics/devteam2.processors[]' | yq 'select("filter/devteam2")')
   if [[ $collectorDeploymentReceiverDevteam2PipelineProcessorFilterConfigCheck != "" ]]; then
     echo "Mode: receiver"

--- a/helm/tests/scripts/03_test_helm_outputs_dep_rec_pipeline.sh
+++ b/helm/tests/scripts/03_test_helm_outputs_dep_rec_pipeline.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+### Set variables
+
+# cluster name
+clusterName="my-dope-cluster"
+
+# otelcollectors
+declare -A otelcollectors
+otelcollectors["name"]="nrotelk8s"
+otelcollectors["namespace"]="monitoring"
+
+runTests() {
+
+  local helmTemplate="$1"
+  local telemetryTypeInput="$2"
+
+  ### Deployment
+  echo ""
+  echo "### ${telemetryTypeInput} ###"
+
+  collectorDeploymentReceiverName="${otelcollectors[name]}-dep-rec"
+
+  ## Collector pipeline configuration
+  echo -e "\n---"
+  echo "Message: Testing collector pipeline configuration for ${telemetryTypeInput}..."
+
+  # Loop through the telemetry types: metrics, traces, logs
+  for telemetryType in metrics traces logs; do
+    echo -e "\n---"
+    echo "Testing ${telemetryType} pipeline configuration..."
+
+    echo "Mode: ${telemetryTypeInput} only"
+    echo "Component: ${telemetryType} pipeline"
+
+    # If the given telemetry type equals to the input telemetry type, then the relevant pipeline must be configured
+    if [[ $telemetryType == $telemetryTypeInput ]]; then
+      check=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentReceiverName}'")).spec.config' | yq '.service.pipelines.'"$entry"'/opsteam')
+      if [[ $check == "" ]]; then
+        echo "Message: Pipeline should be configured but it has not!"
+        exit 1
+      fi
+    # If the given telemetry type does not equal to the input telemetry type, then the relevant pipeline should be null
+    else
+      check=$(echo "$helmTemplate" | yq 'select((.kind == "OpenTelemetryCollector") and (.metadata.name == "'${collectorDeploymentReceiverName}'")).spec.config' | yq '.service.pipelines.'"$entry"'/opsteam')
+      if [[ $check != "null" ]]; then
+        echo "Message: Pipeline should not be configured but it has!"
+        exit 1
+      fi
+    fi    
+  done
+
+  echo "Message: Tests for collector pipelines are run successfully."
+  echo "---"
+}
+
+### Case - Only metrics
+helmTemplate=$(helm template ${otelcollectors[name]} \
+  --create-namespace \
+  --namespace ${otelcollectors[namespace]} \
+  --set clusterName=$clusterName \
+  --set global.newrelic.enabled=true \
+  --set daemonset.enabled=false \
+  --set deployment.enabled=true \
+  --set statefulset.enabled=false \
+  --set singleton.enabled=false \
+  --set global.newrelic.endpoint="https://otlp.nr-data.net" \
+  --set global.newrelic.teams.opsteam.licenseKey.value="value_ops" \
+  --set deployment.receiverPipeline.metrics.enabled=true \
+  --set deployment.receiverPipeline.traces.enabled=false \
+  --set deployment.receiverPipeline.logs.enabled=false \
+  "../../charts/collectors" | yq)
+
+runTests "$helmTemplate" "metrics"
+
+### Case - Only traces
+helmTemplate=$(helm template ${otelcollectors[name]} \
+  --create-namespace \
+  --namespace ${otelcollectors[namespace]} \
+  --set clusterName=$clusterName \
+  --set global.newrelic.enabled=true \
+  --set daemonset.enabled=false \
+  --set deployment.enabled=true \
+  --set statefulset.enabled=false \
+  --set singleton.enabled=false \
+  --set global.newrelic.endpoint="https://otlp.nr-data.net" \
+  --set global.newrelic.teams.opsteam.licenseKey.value="value_ops" \
+  --set deployment.receiverPipeline.metrics.enabled=false \
+  --set deployment.receiverPipeline.traces.enabled=true \
+  --set deployment.receiverPipeline.logs.enabled=false \
+  "../../charts/collectors" | yq)
+
+runTests "$helmTemplate" "traces"
+
+### Case - Only logs
+helmTemplate=$(helm template ${otelcollectors[name]} \
+  --create-namespace \
+  --namespace ${otelcollectors[namespace]} \
+  --set clusterName=$clusterName \
+  --set global.newrelic.enabled=true \
+  --set daemonset.enabled=false \
+  --set deployment.enabled=true \
+  --set statefulset.enabled=false \
+  --set singleton.enabled=false \
+  --set global.newrelic.endpoint="https://otlp.nr-data.net" \
+  --set global.newrelic.teams.opsteam.licenseKey.value="value_ops" \
+  --set deployment.receiverPipeline.metrics.enabled=false \
+  --set deployment.receiverPipeline.traces.enabled=false \
+  --set deployment.receiverPipeline.logs.enabled=true \
+  "../../charts/collectors" | yq)
+
+runTests "$helmTemplate" "logs"


### PR DESCRIPTION
# Changes

- Namings are fixed in `02_test_helm_outputs.sh`.
- Pipeline flags are implemented for `dep-rec` collector instances.
- Relevant tests are implemented with `03_test_helm_outputs_dep_rec_pipeline.sh`.
- `03_test_helm_outputs_dep_rec_pipeline.sh` is added to `validate_helm_output.yml` workflow.