### PR TITLE
fix: add managementState to OTel Collectors

### DIFF
--- a/helm/charts/collectors/Chart.yaml
+++ b/helm/charts/collectors/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.4
+version: 0.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/charts/collectors/templates/daemonset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/daemonset-otelcollector.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ include "nrotel.daemonsetName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-
   # Mode
   mode: "daemonset"
+  managementState: managed
 
   # Service Account
   serviceAccount: {{ include "nrotel.daemonsetName" . }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-receiver.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ include "nrotel.deploymentNameReceiver" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-
   # Mode
   mode: "deployment"
+  managementState: managed
 
   # Service Account
   serviceAccount: {{ include "nrotel.deploymentName" . }}

--- a/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
+++ b/helm/charts/collectors/templates/deployment-otelcollector-sampler.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ include "nrotel.deploymentNameSampler" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-
   # Mode
   mode: "deployment"
+  managementState: managed
 
   # Service Account
   serviceAccount: {{ include "nrotel.deploymentName" . }}

--- a/helm/charts/collectors/templates/singleton-otelcollector.yaml
+++ b/helm/charts/collectors/templates/singleton-otelcollector.yaml
@@ -6,9 +6,10 @@ metadata:
   name: {{ include "nrotel.singletonName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-
   # Mode
   mode: "deployment"
+  managementState: managed
+
 
   # Replicas -> SHOULD BE 1 (obviously...)
   replicas: 1

--- a/helm/charts/collectors/templates/statefulset-otelcollector.yaml
+++ b/helm/charts/collectors/templates/statefulset-otelcollector.yaml
@@ -6,9 +6,9 @@ metadata:
   name: {{ include "nrotel.statefulsetName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-
   # Mode
   mode: "statefulset"
+  managementState: managed
 
   # Service Account
   serviceAccount: {{ include "nrotel.statefulsetName" . }}


### PR DESCRIPTION
# Changes

- added manegementState to all OpenTelemetryCollector to fix schema validation issues

# Error message

`OpenTelemetryCollector nrotelk8s-ds is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/managementState' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/opentelemetry.io/opentelemetrycollector_v1beta1.json#/properties/spec/properties/managementState/enum: value must be one of "managed", "unmanaged"`

# validation command

`helm template test helm/charts/collectors/ --set clusterName=test,global.newrelic.teams.opsteam.licenseKey.value=test | kubeconform -schema-location default -schema-location "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/{{.NormalizedKubernetesVersion}}/{{.ResourceKind}}.json" -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'`